### PR TITLE
Fixing camera res / making text actually work

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -23,9 +23,8 @@ Tools="*res://global_scripts/tools.gd"
 
 [display]
 
-window/size/viewport_width=640
-window/size/viewport_height=360
-window/size/mode=2
+window/size/viewport_width=960
+window/size/viewport_height=540
 window/stretch/mode="viewport"
 
 [dotnet]
@@ -70,7 +69,7 @@ action={
 
 [rendering]
 
-textures/canvas_textures/default_texture_filter=3
+textures/canvas_textures/default_texture_filter=0
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
 textures/decals/filter=2

--- a/scenes/camera.gd
+++ b/scenes/camera.gd
@@ -5,15 +5,15 @@ const DESIRED_WIDTH: float = 0.7 #0.2 = 20%
 const DESIRED_HEIGHT: float = 0.3 #0.2 = 20%
 
 func _ready() -> void:
-	#Need to get the camera's rect from the camera position and the viewport size
-	var half_size = get_viewport_rect().size * 0.5
-	var camera_rect = Rect2(position - half_size, position + half_size)
+	#This is magic found from this lovely individual, fixed up to match Godot 4 docs
+	#https://www.reddit.com/r/godot/comments/rzmfh3/comment/hrwd6mz/?utm_source=share&utm_medium=web2x&context=3
+	var camera_rect = get_canvas_transform().affine_inverse().basis_xform(get_viewport_rect().size)
 	
 	#Note the chat window is anchored top-left and is currently at 0,0
-	var width = camera_rect.size.x * DESIRED_WIDTH
-	var height = camera_rect.size.y * DESIRED_HEIGHT
+	var width = camera_rect.x * DESIRED_WIDTH
+	var height = camera_rect.y * DESIRED_HEIGHT
 	
-	var x_pos = (camera_rect.size.x - width) / 2
-	var y_pos = camera_rect.size.y - height - BOTTOM_MARGIN
+	var x_pos = -width / 2
+	var y_pos = height / 2 + BOTTOM_MARGIN
 	
 	get_parent().get_node("ChatWindow").configure_initial_box(Vector2(x_pos, y_pos), width, height)

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -264,10 +264,6 @@ position_smoothing_speed = 10.0
 script = ExtResource("4_ugbdj")
 
 [node name="ChatWindow" parent="." instance=ExtResource("4_jlcc3")]
-offset_left = -161.0
-offset_top = -90.0
-offset_right = -161.0
-offset_bottom = -90.0
 
 [node name="Area2D" type="Area2D" parent="."]
 


### PR DESCRIPTION
The resolution scaling was so bad due to the pixel art being 16 pixels, that text couldn't be downsized anymore. In that case, had to change the stretch mode, as well as fix the chat window once and for all.